### PR TITLE
Fix slug handling in URL generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,9 @@ Manually constructing URLs for SEO purposes can be time-consuming and prone to e
 
 ## 3. Features:
 * Automatically builds URLs using values entered in specific columns.
-* Encodes categories and keywords for valid URL formatting.
-* Transforms spaces in keywords into hyphens, making them SEO-friendly.
+* Encodes categories, sub-categories and keywords for valid URL formatting.
+* Transforms spaces in keywords, categories and sub-categories into hyphens, making them SEO-friendly.
+* Removes any trailing slashes from the domain to avoid duplicate separators.
 * Supports an optional sub-category field for more detailed URL structuring.
 
 ## 3.1. How Does It Work? 

--- a/web url maker.js
+++ b/web url maker.js
@@ -5,7 +5,7 @@ function onEdit(e) {
   // Check if the edit is within the relevant columns (A to D)
   if (range.getColumn() >= 1 && range.getColumn() <= 4) {
     var row = range.getRow();
-    
+
     // Get values from Columns A, B, C, D (Domain, Category, Sub Category, Keyword)
     var domain = sheet.getRange(row, 1).getValue(); // Column A
     var category = sheet.getRange(row, 2).getValue(); // Column B
@@ -14,17 +14,26 @@ function onEdit(e) {
 
     // Check if all fields are filled out before creating the URL
     if (domain && category && keyword) {
+      // Clean and slugify components
+      domain = String(domain).trim().replace(/\/+$/, '');
+      var categorySlug = encodeURIComponent(String(category).trim().replace(/\s+/g, '-').toLowerCase());
+      var keywordSlug = encodeURIComponent(String(keyword).trim().replace(/\s+/g, '-').toLowerCase());
+
       // Construct the URL
-      var url = domain + '/' + encodeURIComponent(category);
+      var url = domain + '/' + categorySlug;
 
       if (subCategory) {
-        url += '/' + encodeURIComponent(subCategory);
+        var subCategorySlug = encodeURIComponent(String(subCategory).trim().replace(/\s+/g, '-').toLowerCase());
+        url += '/' + subCategorySlug;
       }
 
-      url += '/' + encodeURIComponent(keyword.replace(/\s+/g, '-').toLowerCase());
+      url += '/' + keywordSlug;
 
       // Set the result in Column E
       sheet.getRange(row, 5).setValue(url);
+    } else {
+      // Clear the URL cell if required fields are missing
+      sheet.getRange(row, 5).setValue('');
     }
   }
 }


### PR DESCRIPTION
## Summary
- clean domain values before constructing URLs
- slugify category, sub-category and keyword
- clear the output cell when any required field is missing
- document slug behaviour in README

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_684174dc45e0832086f51a974fb279ba