### PR TITLE
Fix slug handling in URL generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,9 +21,12 @@ Manually constructing URLs for SEO purposes can be time-consuming and prone to e
 
 ## 3. Features:
 * Automatically builds URLs using values entered in specific columns.
-* Encodes categories and keywords for valid URL formatting.
-* Transforms spaces in keywords into hyphens, making them SEO-friendly.
+* Encodes categories, sub-categories and keywords for valid URL formatting.
+* Transforms spaces in keywords, categories and sub-categories into hyphens, making them SEO-friendly.
+* Removes any trailing slashes from the domain and normalizes it to lowercase to avoid duplicate separators.
 * Supports an optional sub-category field for more detailed URL structuring.
+* Clears the URL cell if any required field is missing.
+* Works when pasting data across multiple rows at once.
 
 ## 3.1. How Does It Work? 
 * Column A: Domain

--- a/web url maker.js
+++ b/web url maker.js
@@ -1,30 +1,48 @@
+function slugify(value) {
+  return encodeURIComponent(String(value).trim().replace(/\s+/g, '-').toLowerCase());
+}
+
 function onEdit(e) {
-  var sheet = e.source.getActiveSheet();
+  var sheet = e.range.getSheet();
   var range = e.range;
 
   // Check if the edit is within the relevant columns (A to D)
   if (range.getColumn() >= 1 && range.getColumn() <= 4) {
-    var row = range.getRow();
-    
-    // Get values from Columns A, B, C, D (Domain, Category, Sub Category, Keyword)
-    var domain = sheet.getRange(row, 1).getValue(); // Column A
-    var category = sheet.getRange(row, 2).getValue(); // Column B
-    var subCategory = sheet.getRange(row, 3).getValue(); // Column C
-    var keyword = sheet.getRange(row, 4).getValue(); // Column D
+    var startRow = range.getRow();
+    var numRows = range.getNumRows();
 
-    // Check if all fields are filled out before creating the URL
-    if (domain && category && keyword) {
-      // Construct the URL
-      var url = domain + '/' + encodeURIComponent(category);
+    for (var i = 0; i < numRows; i++) {
+      var row = startRow + i;
 
-      if (subCategory) {
-        url += '/' + encodeURIComponent(subCategory);
+      // Get values from Columns A, B, C, D (Domain, Category, Sub Category, Keyword)
+      var domain = sheet.getRange(row, 1).getValue(); // Column A
+      var category = sheet.getRange(row, 2).getValue(); // Column B
+      var subCategory = sheet.getRange(row, 3).getValue(); // Column C
+      var keyword = sheet.getRange(row, 4).getValue(); // Column D
+
+      // Check if all fields are filled out before creating the URL
+      if (domain && category && keyword) {
+        // Clean and slugify components
+        domain = String(domain).trim().replace(/\/+$/, '').toLowerCase();
+        var categorySlug = slugify(category);
+        var keywordSlug = slugify(keyword);
+
+        // Construct the URL
+        var url = domain + '/' + categorySlug;
+
+        if (subCategory) {
+          var subCategorySlug = slugify(subCategory);
+          url += '/' + subCategorySlug;
+        }
+
+        url += '/' + keywordSlug;
+
+        // Set the result in Column E
+        sheet.getRange(row, 5).setValue(url);
+      } else {
+        // Clear the URL cell if required fields are missing
+        sheet.getRange(row, 5).setValue('');
       }
-
-      url += '/' + encodeURIComponent(keyword.replace(/\s+/g, '-').toLowerCase());
-
-      // Set the result in Column E
-      sheet.getRange(row, 5).setValue(url);
     }
   }
 }


### PR DESCRIPTION
## Summary
- clean domain values before constructing URLs
- slugify category, sub-category and keyword
- clear the output cell when any required field is missing
- handle multi-row edits
- document slug behaviour in README
- normalize domain case and simplify slug logic

## Testing
- `node -v`


------
https://chatgpt.com/codex/tasks/task_e_684174dc45e0832086f51a974fb279ba